### PR TITLE
Install apt-transport-https

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+apt_repository_enable_https: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: install apt-transport-https
+  apt:
+    name: apt-transport-https
+    state: present
+  when: apt_repository_enable_https
+
 - name: add apt repo
   apt_repository: repo='{{ item.repo }}' state=present
   with_items: "{{ apt_repository_repositories }}"


### PR DESCRIPTION
I suggest to install `apt-transport-https` package by default. Most of current repositories are available https only
